### PR TITLE
fix: Update backend port configuration to use environment variable

### DIFF
--- a/backend/dist/index.js
+++ b/backend/dist/index.js
@@ -52,7 +52,7 @@ const userRoutes_1 = __importDefault(require("./routes/userRoutes"));
 const swagger_output_json_1 = __importDefault(require("./swagger_output.json"));
 dotenv_1.default.config();
 const app = (0, express_1.default)();
-const port = process.env.BACKEND_PORT;
+const port = process.env.PORT || 4000;
 app.use((0, cors_1.default)({ origin: config_1.CLIENT_URL }));
 app.use(express_1.default.json());
 app.use(passport_1.default.initialize());

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -16,7 +16,7 @@ import swaggerOutput from "./swagger_output.json";
 dotenv.config();
 
 const app = express();
-const port = process.env.BACKEND_PORT;
+const port = process.env.PORT || 4000;
 
 app.use(cors({ origin: CLIENT_URL }));
 app.use(express.json());


### PR DESCRIPTION
- Changed backend port configuration to use process.env.PORT with a fallback to 4000, ensuring flexibility in deployment environments.